### PR TITLE
initial appveyor.yml CI config

### DIFF
--- a/CADdyTools/CADdyTools.csproj
+++ b/CADdyTools/CADdyTools.csproj
@@ -238,7 +238,7 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildProjectDirectory)\PluginInfrastructure\DllExport\NppPlugin.DllExport.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(ProjectDir)CADdyTools_Lang.ini " "C:\Program Files\Notepad++\plugins\$(ProjectName)\"</PostBuildEvent>
+    <PostBuildEvent Condition="exists('C:\Program Files\Notepad++\plugins')">copy "$(ProjectDir)CADdyTools_Lang.ini " "C:\Program Files\Notepad++\plugins\$(ProjectName)\"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,50 @@
+version: 1.0.0.2{build}
+image: Visual Studio 2017
+
+
+platform:
+    - Any CPU
+    - x86
+    - x64
+
+configuration:
+    - Release
+    - Debug
+
+install:
+    - if "%platform%"=="Any CPU" set archi=x86
+    - if "%platform%"=="Any CPU" set platform_input=Any CPU
+    - if "%platform%"=="x86" set archi=x86
+    - if "%platform%"=="x86" set platform_input=x86
+    - if "%platform%"=="x64" set archi=amd_x64
+    - if "%platform%"=="x64" set platform_input=x64
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild CADdyTools.sln /m /p:configuration="%configuration%" /p:platform="%platform_input%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - ps: >-
+        Push-AppveyorArtifact "CADdyTools\bin\$env:CONFIGURATION\CADdyTools.dll" -FileName CADdyTools.dll
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release") {
+            $ZipFileName = "CADdyTools_$($env:APPVEYOR_REPO_TAG_NAME)_$($env:PLATFORM_INPUT).zip"
+            7z a $ZipFileName "%APPVEYOR_BUILD_FOLDER%\CADdyTools\bin\$env:CONFIGURATION\CADdyTools.dll"
+        }
+
+artifacts:
+  - path: CADdyTools_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        configuration: Release


### PR DESCRIPTION
CI build with appveyor (see https://ci.appveyor.com/project/chcg/caddytools/builds/31337339)
Might be also done via github actions.
Consider to remove build configuration of Any CPU as it is not usable with N++.